### PR TITLE
[Bug/BAR-84] 도커 환경에서 husky 설치 방지

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "prepare": "husky install",
-    "postinstall": "husky install",
+    "prepare": "if [ -z \"$PNPM_HOME\" ]; then husky install ; fi",
+    "postinstall": "if [ -z \"$PNPM_HOME\" ]; then husky install ; fi",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
# 이 PR은요 !

## Summary

> 구현 내용 및 작업한 내역을 요약해서 적어주세요

- [x] 1b257035598cba301a6e71b12458ca15e3dc8d4f docker 환경에서 허스키 설치를 막습니다

## To Reviewers

husky를 설치하지 않은 상태에서 husky 명령어를 사용하고 있어서 배포 에러가 발생하고 있습니다.
도커 환경에서 사용하고 있는 `PNPM_HOME` 이라는 `ENV`의 유무를 확인하여 `husky install`을 할지 결정합니다.

## How To Test

- `docker build .` 시 이미지가 정상 생성되는지 확인이 필요합니다.
