### PR TITLE
[Feature/BAR-139] Tooltip 컴포넌트 구현

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -26,8 +26,9 @@ const meta: Meta<typeof Tooltip> = {
         style={{
           display: 'flex',
           justifyContent: 'center',
+          alignItems: 'center',
           gap: '200px',
-          padding: '60px 0',
+          height: '550px',
         }}
       >
         <Story />
@@ -60,12 +61,22 @@ export const Basic: Story = {
 };
 
 export const Minimal: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Hover시 Trigger 요소의 상위와 하위에 노출됩니다.',
+      },
+    },
+  },
   args: {
     children: 'Minimal',
-    hasArrow: false,
+    placement: 'bottom',
+  },
+  argTypes: {
+    hasArrow: { control: false },
   },
   render: (args) => (
-    <Tooltip hasArrow={args.hasArrow}>
+    <Tooltip hasArrow={false} placement={args.placement}>
       <Tooltip.Trigger>
         <div>{args.children}</div>
       </Tooltip.Trigger>
@@ -75,12 +86,22 @@ export const Minimal: Story = {
 };
 
 export const Highlight: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Hover시 Trigger 요소의 하위에 노출됩니다.',
+      },
+    },
+  },
   args: {
     children: 'Highlight',
     hasArrow: true,
   },
+  argTypes: {
+    placement: { control: false },
+  },
   render: (args) => (
-    <Tooltip hasArrow={args.hasArrow}>
+    <Tooltip hasArrow={args.hasArrow} placement="bottom">
       <Tooltip.Trigger>
         <div>{args.children}</div>
       </Tooltip.Trigger>

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -70,13 +70,11 @@ export const Minimal: Story = {
   },
   args: {
     children: 'Minimal',
+    hasArrow: false,
     placement: 'bottom',
   },
-  argTypes: {
-    hasArrow: { control: false },
-  },
   render: (args) => (
-    <Tooltip placement={args.placement}>
+    <Tooltip hasArrow={args.hasArrow} placement={args.placement}>
       <Tooltip.Trigger>
         <div>{args.children}</div>
       </Tooltip.Trigger>
@@ -96,12 +94,10 @@ export const Highlight: Story = {
   args: {
     children: 'Highlight',
     hasArrow: true,
-  },
-  argTypes: {
-    placement: { control: false },
+    placement: 'bottom',
   },
   render: (args) => (
-    <Tooltip hasArrow={args.hasArrow}>
+    <Tooltip hasArrow={args.hasArrow} placement={args.placement}>
       <Tooltip.Trigger>
         <div>{args.children}</div>
       </Tooltip.Trigger>

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Tooltip from './Tooltip';
+
+const COMPONENT_DESCRIPTION = `
+  - \`<Tooltip />\`: 모든 컴포넌트에 대한 컨텍스트와 상태를 제공합니다.
+  - \`<Tooltip.Trigger />\`: \`<Tabs.Content />\` 컴포넌트를 활성화하는 컴포넌트입니다. 사용자가 이 컴포넌트 위로 마우스를 올릴 때 Tooltip이 나타납니다.
+  - \`<Tooltip.Content />\`: Tooltip에 표시되는 내용을 담당하는 컴포넌트입니다.
+`;
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  parameters: {
+    componentSubtitle:
+      '특정 사용자 인터페이스에 대한 보조 설명을 제공하는 컴포넌트',
+    docs: {
+      description: {
+        component: COMPONENT_DESCRIPTION,
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          gap: '200px',
+          padding: '60px 0',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const Basic: Story = {
+  render: () => (
+    <>
+      <Tooltip>
+        <Tooltip.Trigger>
+          <div>Minimal</div>
+        </Tooltip.Trigger>
+        <Tooltip.Content>Minimal Tooltip 설명</Tooltip.Content>
+      </Tooltip>
+      <Tooltip hasArrow>
+        <Tooltip.Trigger>
+          <div>Highlight</div>
+        </Tooltip.Trigger>
+        <Tooltip.Content>Highlight Tooltip 설명</Tooltip.Content>
+      </Tooltip>
+    </>
+  ),
+};
+
+export const Minimal: Story = {
+  args: {
+    children: 'Minimal',
+    hasArrow: false,
+  },
+  render: (args) => (
+    <Tooltip hasArrow={args.hasArrow}>
+      <Tooltip.Trigger>
+        <div>{args.children}</div>
+      </Tooltip.Trigger>
+      <Tooltip.Content>Minimal Tooltip 설명</Tooltip.Content>
+    </Tooltip>
+  ),
+};
+
+export const Highlight: Story = {
+  args: {
+    children: 'Highlight',
+    hasArrow: true,
+  },
+  render: (args) => (
+    <Tooltip hasArrow={args.hasArrow}>
+      <Tooltip.Trigger>
+        <div>{args.children}</div>
+      </Tooltip.Trigger>
+      <Tooltip.Content>Highlight Tooltip 설명</Tooltip.Content>
+    </Tooltip>
+  ),
+};

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -76,7 +76,7 @@ export const Minimal: Story = {
     hasArrow: { control: false },
   },
   render: (args) => (
-    <Tooltip hasArrow={false} placement={args.placement}>
+    <Tooltip placement={args.placement}>
       <Tooltip.Trigger>
         <div>{args.children}</div>
       </Tooltip.Trigger>
@@ -101,7 +101,7 @@ export const Highlight: Story = {
     placement: { control: false },
   },
   render: (args) => (
-    <Tooltip hasArrow={args.hasArrow} placement="bottom">
+    <Tooltip hasArrow={args.hasArrow}>
       <Tooltip.Trigger>
         <div>{args.children}</div>
       </Tooltip.Trigger>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,86 @@
+import type { PropsWithChildren, Ref } from 'react';
+import { createContext, useEffect, useRef, useState } from 'react';
+
+import TooltipContent from './TooltipContent';
+import TooltipTrigger from './TooltipTrigger';
+
+const INIT_POSITION = { top: 0, left: 0 };
+const TOOLTIP_MARGIN = 4;
+const TOOLTIP_PADDING = 16;
+
+interface TooltipContextProps {
+  tooltipRef: Ref<HTMLDivElement>;
+  isVisible: boolean;
+  hasArrow?: boolean;
+  position: typeof INIT_POSITION;
+  onOpenTooltip: () => void;
+  onCloseTooltip: () => void;
+}
+
+interface TooltipProps {
+  hasArrow?: boolean;
+}
+
+export const TooltipContext = createContext<TooltipContextProps | null>(null);
+
+const TooltipRoot = ({
+  children,
+  hasArrow = false,
+}: PropsWithChildren<TooltipProps>) => {
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const [isVisible, setIsVisible] = useState(false);
+  const [position, setPosition] = useState(INIT_POSITION);
+
+  useEffect(() => {
+    if (tooltipRef.current && isVisible) {
+      const { x, y, width, height } =
+        tooltipRef.current.getBoundingClientRect();
+      const { scrollY } = window;
+
+      let positionTop: number;
+      const positionLeft = x + width / 2;
+
+      if (hasArrow) {
+        positionTop = scrollY + y + height + TOOLTIP_MARGIN;
+      } else {
+        positionTop = scrollY + y - height - TOOLTIP_MARGIN - TOOLTIP_PADDING;
+      }
+
+      setPosition({
+        top: positionTop,
+        left: positionLeft,
+      });
+    }
+  }, [isVisible, hasArrow]);
+
+  const handleTooltipOpen = () => {
+    setIsVisible(true);
+  };
+
+  const handleTooltipClose = () => {
+    setIsVisible(false);
+  };
+
+  return (
+    <TooltipContext.Provider
+      value={{
+        tooltipRef,
+        isVisible,
+        hasArrow,
+        position,
+        onOpenTooltip: handleTooltipOpen,
+        onCloseTooltip: handleTooltipClose,
+      }}
+    >
+      {children}
+    </TooltipContext.Provider>
+  );
+};
+
+const Tooltip = Object.assign(TooltipRoot, {
+  Trigger: TooltipTrigger,
+  Content: TooltipContent,
+});
+
+export default Tooltip;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -7,22 +7,21 @@ import TooltipContent from './TooltipContent';
 import TooltipTrigger from './TooltipTrigger';
 
 const INIT_POSITION = { top: 0, left: 0 };
-const MINIMAL_TOOLTIP_PADDING = 8;
 
-export type Placement = 'top' | 'bottom';
+export interface TooltipShape {
+  hasArrow?: boolean;
+  placement?: 'top' | 'bottom';
+}
 
-interface TooltipContextProps {
+interface TooltipContextProps extends TooltipShape {
   tooltipRef: Ref<HTMLDivElement>;
   isVisible: boolean;
-  hasArrow?: boolean;
-  placement?: Placement;
   position: typeof INIT_POSITION;
   onOpenTooltip: () => void;
   onCloseTooltip: () => void;
 }
 
-interface TooltipProps
-  extends Pick<TooltipContextProps, 'hasArrow' | 'placement'> {}
+interface TooltipProps extends TooltipShape {}
 
 export const TooltipContext = createContext<TooltipContextProps | null>(null);
 
@@ -41,16 +40,9 @@ const TooltipRoot = ({
       return;
     }
 
-    const { top, left } = getPosition(tooltipRef.current, placement);
+    const { top, left } = getPosition(tooltipRef.current, hasArrow, placement);
 
-    if (!hasArrow && placement === 'top') {
-      setPosition({
-        top: top - MINIMAL_TOOLTIP_PADDING,
-        left,
-      });
-    } else {
-      setPosition({ top, left });
-    }
+    setPosition({ top, left });
   }, [isVisible, hasArrow, placement]);
 
   const handleTooltipOpen = () => {
@@ -67,6 +59,7 @@ const TooltipRoot = ({
         tooltipRef,
         isVisible,
         hasArrow,
+        placement,
         position,
         onOpenTooltip: handleTooltipOpen,
         onCloseTooltip: handleTooltipClose,

--- a/src/components/Tooltip/TooltipContent.tsx
+++ b/src/components/Tooltip/TooltipContent.tsx
@@ -1,20 +1,29 @@
 import type { PropsWithChildren } from 'react';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
+import clsx from 'clsx';
 
 import { useTooltipContext } from '@/src/hooks/useTooltipContext';
 
 import * as styles from './style.css';
 import TooltipPortal from './TooltipPortal';
 
+const ARROW_STYLE = {
+  top: styles.bottomArrow,
+  bottom: styles.topArrow,
+};
+
 const TooltipContent = ({ children }: PropsWithChildren) => {
-  const { isVisible, hasArrow, position } = useTooltipContext();
+  const { isVisible, hasArrow, placement, position } = useTooltipContext();
 
   return (
     <>
       {isVisible && (
         <TooltipPortal>
           <div
-            className={styles.content({ hasArrow })}
+            className={clsx(
+              styles.content({ hasArrow }),
+              hasArrow && ARROW_STYLE[placement],
+            )}
             style={assignInlineVars({
               [styles.top]: `${position.top}px`,
               [styles.left]: `${position.left}px`,

--- a/src/components/Tooltip/TooltipContent.tsx
+++ b/src/components/Tooltip/TooltipContent.tsx
@@ -1,0 +1,27 @@
+import type { PropsWithChildren } from 'react';
+
+import { useTooltipContext } from '@/src/hooks/useTooltipContext';
+
+import * as styles from './style.css';
+import TooltipPortal from './TooltipPortal';
+
+const TooltipContent = ({ children }: PropsWithChildren) => {
+  const { isVisible, hasArrow, position } = useTooltipContext();
+
+  return (
+    <>
+      {isVisible && (
+        <TooltipPortal>
+          <div
+            className={styles.content({ hasArrow })}
+            style={{ top: position.top, left: position.left }}
+          >
+            {children}
+          </div>
+        </TooltipPortal>
+      )}
+    </>
+  );
+};
+
+export default TooltipContent;

--- a/src/components/Tooltip/TooltipContent.tsx
+++ b/src/components/Tooltip/TooltipContent.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from 'react';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
 
 import { useTooltipContext } from '@/src/hooks/useTooltipContext';
 
@@ -14,7 +15,10 @@ const TooltipContent = ({ children }: PropsWithChildren) => {
         <TooltipPortal>
           <div
             className={styles.content({ hasArrow })}
-            style={{ top: position.top, left: position.left }}
+            style={assignInlineVars({
+              [styles.top]: `${position.top}px`,
+              [styles.left]: `${position.left}px`,
+            })}
           >
             {children}
           </div>

--- a/src/components/Tooltip/TooltipPortal.tsx
+++ b/src/components/Tooltip/TooltipPortal.tsx
@@ -1,0 +1,29 @@
+import type { ReactElement } from 'react';
+import { useEffect } from 'react';
+import ReactDOM from 'react-dom';
+
+interface TooltipPortalProps {
+  children: ReactElement;
+}
+
+const TOOLTIP_PORTAL_ID = 'tooltip-root';
+const TOOLTIP_ROOT_TAG = 'div';
+
+const TooltipPortal = ({ children }: TooltipPortalProps) => {
+  const tooltipRoot = document.createElement(TOOLTIP_ROOT_TAG);
+  tooltipRoot.id = TOOLTIP_PORTAL_ID;
+
+  useEffect(() => {
+    if (tooltipRoot) {
+      document.body.appendChild(tooltipRoot);
+    }
+
+    return () => {
+      document.body.removeChild(tooltipRoot);
+    };
+  }, [tooltipRoot]);
+
+  return ReactDOM.createPortal(children, tooltipRoot);
+};
+
+export default TooltipPortal;

--- a/src/components/Tooltip/TooltipTrigger.tsx
+++ b/src/components/Tooltip/TooltipTrigger.tsx
@@ -1,0 +1,22 @@
+import { type PropsWithChildren } from 'react';
+
+import { useTooltipContext } from '@/src/hooks/useTooltipContext';
+
+import * as styles from './style.css';
+
+const TooltipTrigger = ({ children }: PropsWithChildren) => {
+  const { tooltipRef, onOpenTooltip, onCloseTooltip } = useTooltipContext();
+
+  return (
+    <div
+      ref={tooltipRef}
+      className={styles.trigger}
+      onMouseEnter={onOpenTooltip}
+      onMouseLeave={onCloseTooltip}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default TooltipTrigger;

--- a/src/components/Tooltip/style.css.ts
+++ b/src/components/Tooltip/style.css.ts
@@ -35,7 +35,6 @@ export const content = recipe({
         padding: '8px 12px',
       },
       true: {
-        marginTop: '6px',
         padding: '16px',
 
         '::before': {
@@ -43,13 +42,29 @@ export const content = recipe({
           width: 0,
           height: 0,
           position: 'absolute',
-          top: '-12px',
           left: '50%',
           transform: 'translateX(-50%)',
           border: `6px solid ${COLORS['Grey/White']}`,
-          borderBottomColor: COLORS['Dim/70'],
         },
       },
     },
+  },
+});
+
+export const topArrow = style({
+  marginTop: '6px',
+
+  '::before': {
+    top: '-12px',
+    borderBottomColor: COLORS['Dim/70'],
+  },
+});
+
+export const bottomArrow = style({
+  marginBottom: '6px',
+
+  '::before': {
+    bottom: '-12px',
+    borderTopColor: COLORS['Dim/70'],
   },
 });

--- a/src/components/Tooltip/style.css.ts
+++ b/src/components/Tooltip/style.css.ts
@@ -1,0 +1,47 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { sprinkles } from '@/src/styles/sprinkles.css';
+import { COLORS, Z_INDEX } from '@/src/styles/tokens';
+
+export const trigger = style({
+  width: 'fit-content',
+});
+
+export const content = recipe({
+  base: [
+    sprinkles({ typography: '13/Body/Regular' }),
+    {
+      position: 'absolute',
+      width: 'fit-content',
+      color: COLORS['Grey/White'],
+      backgroundColor: COLORS['Dim/70'],
+      borderRadius: '8px',
+      transform: 'translateX(-50%)',
+      zIndex: Z_INDEX['tooltip'],
+    },
+  ],
+  variants: {
+    hasArrow: {
+      false: {
+        padding: '8px 12px',
+      },
+      true: {
+        marginTop: '6px',
+        padding: '16px',
+
+        '::before': {
+          content: '',
+          width: 0,
+          height: 0,
+          position: 'absolute',
+          top: '-12px',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          border: `6px solid ${COLORS['Grey/White']}`,
+          borderBottomColor: COLORS['Dim/70'],
+        },
+      },
+    },
+  },
+});

--- a/src/components/Tooltip/style.css.ts
+++ b/src/components/Tooltip/style.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { createVar, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { sprinkles } from '@/src/styles/sprinkles.css';
@@ -6,17 +6,25 @@ import { COLORS, Z_INDEX } from '@/src/styles/tokens';
 
 export const trigger = style({
   width: 'fit-content',
+  height: 'fit-content',
+  padding: '4px',
 });
+
+export const top = createVar();
+export const left = createVar();
 
 export const content = recipe({
   base: [
     sprinkles({ typography: '13/Body/Regular' }),
     {
       position: 'absolute',
+      top,
+      left,
       width: 'fit-content',
       color: COLORS['Grey/White'],
       backgroundColor: COLORS['Dim/70'],
       borderRadius: '8px',
+      whiteSpace: 'nowrap',
       transform: 'translateX(-50%)',
       zIndex: Z_INDEX['tooltip'],
     },

--- a/src/hooks/useTooltipContext.ts
+++ b/src/hooks/useTooltipContext.ts
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+
+import { TooltipContext } from '../components/Tooltip/Tooltip';
+
+export const useTooltipContext = () => {
+  const ctx = useContext(TooltipContext);
+
+  if (!ctx) {
+    throw new Error(
+      'useTooltipContext hook must be used within a Tooltip component',
+    );
+  }
+
+  return ctx;
+};

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -167,3 +167,8 @@ export const COLORS = {
   LightRed: '#fd6666',
   Purple: '#7c62ea',
 };
+
+export const Z_INDEX = {
+  modal: 100,
+  tooltip: 50,
+};

--- a/src/utils/getPosition.ts
+++ b/src/utils/getPosition.ts
@@ -1,17 +1,24 @@
-import type { Placement } from '../components/Tooltip/Tooltip';
+import type { TooltipShape } from '../components/Tooltip/Tooltip';
+
+const TOOLTIP_MARGIN = {
+  MINIMAL: 8,
+  HIGHLIGHT: 32,
+};
 
 export const getPosition = (
   triggerElement: HTMLDivElement,
-  placement: Placement,
+  hasArrow: TooltipShape['hasArrow'],
+  placement: TooltipShape['placement'],
 ) => {
   const { x, y, width, height } = triggerElement.getBoundingClientRect();
   const { scrollX, scrollY } = window;
 
+  const margin = hasArrow ? TOOLTIP_MARGIN.HIGHLIGHT : TOOLTIP_MARGIN.MINIMAL;
   const left = x + scrollX + width / 2;
 
   switch (placement) {
     case 'top':
-      return { top: y + scrollY - height, left };
+      return { top: y + scrollY - height - margin, left };
     case 'bottom':
       return { top: y + scrollY + height, left };
     default:

--- a/src/utils/getPosition.ts
+++ b/src/utils/getPosition.ts
@@ -1,0 +1,20 @@
+import type { Placement } from '../components/Tooltip/Tooltip';
+
+export const getPosition = (
+  triggerElement: HTMLDivElement,
+  placement: Placement,
+) => {
+  const { x, y, width, height } = triggerElement.getBoundingClientRect();
+  const { scrollX, scrollY } = window;
+
+  const left = x + scrollX + width / 2;
+
+  switch (placement) {
+    case 'top':
+      return { top: y + scrollY - height, left };
+    case 'bottom':
+      return { top: y + scrollY + height, left };
+    default:
+      throw new Error(`The placement value must be either 'top' or 'bottom'.`);
+  }
+};


### PR DESCRIPTION
# 이 PR은요 !

## Summary

> 구현 내용 및 작업한 내역을 요약해서 적어주세요

<img width="442" alt="image" src="https://github.com/YAPP-Github/23rd-Web-Team-2-FE/assets/76807107/b269c47c-2c6a-4707-9abb-3b68e5f70ef6">


- [x] [Tooltip 컴포넌트 구현](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/commit/768c33ada9902f37d8afab764be615a084c044a8)
- [x] [Tooltip 컴포넌트 스토리북 추가](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/commit/b9a69c19b14656ffb9192427d300cd47cea11226)
- [x] [위치 계산 유틸 함수 생성](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/pull/25/commits/5056bd8e2930de87b4ee49b3fa228f174406c52d) 

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점을 적어주세요

- `z-index` token도 상수화해두었는데 값이 적절한지 확인해주세요.
- Minimal Tooltip의 경우, Hover시 Trigger 요소의 상위와 하위에 노출되어야 해요.
- Highlight Tooltip의 경우, Hover시 Trigger 요소의 하위에만 노출되어야 해요.

## How To Test

> PR의 기능을 확인하는 방법을 상세하게 적어주세요

- 스토리북 확인해주세요!
