### PR TITLE
[Fix/BAR-235] Dropdown 컴포넌트 위치 오류 해결

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,4 +1,2 @@
 <div id="modal-root" />
 <div id="toast-root" />
-<div id="tooltip-root" />
-<div id="dropdown-root" />

--- a/src/components/Dropdown/components/DropdownList.tsx
+++ b/src/components/Dropdown/components/DropdownList.tsx
@@ -1,31 +1,25 @@
 import { type PropsWithChildren } from 'react';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 
-import Portal from '@components/Portal';
-import { PORTAL_ID } from '@constants/portal';
-
 import { useDropdownContext } from '..';
 import * as styles from '../style.css';
 
 const DropdownList = ({ children }: PropsWithChildren) => {
-  const { size, targetRef, position, fixed, isOpen } = useDropdownContext();
+  const { isOpen, targetRef, size, position } = useDropdownContext();
 
   return (
     <>
       {isOpen && (
-        <Portal id={PORTAL_ID['DROPDOWN']}>
-          <ul
-            ref={targetRef}
-            className={styles.menuList({ size })}
-            style={assignInlineVars({
-              [styles.position]: fixed ? 'fixed' : 'absolute',
-              [styles.top]: `${position.top}px`,
-              [styles.left]: `${position.left}px`,
-            })}
-          >
-            {children}
-          </ul>
-        </Portal>
+        <ul
+          ref={targetRef}
+          className={styles.menuList({ size })}
+          style={assignInlineVars({
+            [styles.top]: `${position.top}px`,
+            [styles.left]: `${position.left}px`,
+          })}
+        >
+          {children}
+        </ul>
       )}
     </>
   );

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -28,8 +28,6 @@ interface DropdownContextProps {
   position: typeof INIT_POSITION;
   /** dropdown menulist 요소의 ref 객체  */
   targetRef: RefObject<HTMLUListElement>;
-  /** dropdown menulist css position fixed 적용 여부 */
-  fixed?: boolean;
   /** dropdown menulist 열림, 닫힘 상태 */
   isOpen: boolean;
   /** dropdown trigger toggle 함수 */
@@ -38,7 +36,7 @@ interface DropdownContextProps {
 
 interface DropdownRootProps
   extends HTMLAttributes<HTMLDivElement>,
-    Pick<DropdownContextProps, 'size' | 'placement' | 'fixed'> {
+    Pick<DropdownContextProps, 'size' | 'placement'> {
   className?: HTMLAttributes<HTMLDivElement>['className'];
 }
 
@@ -48,19 +46,17 @@ const DropdownRoot = ({
   children,
   size = 'small',
   placement = 'bottom-left',
-  fixed = false,
   ...props
 }: PropsWithChildren<DropdownRootProps>) => {
   const { isOpen, onClose, onToggle } = useDisclosure();
   const dropdownRef = useClickAway({
     onClickAway: onClose,
-  });
+  })!;
   const { targetRef, position } = usePosition<HTMLDivElement, HTMLUListElement>(
     {
       defaultTriggerRef: dropdownRef,
       isOpen,
       placement,
-      fixed,
     },
   );
 
@@ -71,7 +67,6 @@ const DropdownRoot = ({
         placement,
         position,
         targetRef,
-        fixed,
         isOpen,
         onToggle,
       }}

--- a/src/components/Dropdown/style.css.ts
+++ b/src/components/Dropdown/style.css.ts
@@ -14,13 +14,12 @@ export const trigger = style({
   width: 'fit-content',
 });
 
-export const position = createVar();
 export const top = createVar();
 export const left = createVar();
 
 export const menuList = recipe({
   base: {
-    position,
+    position: 'absolute',
     top,
     left,
     marginTop: '4px',

--- a/src/components/Layout/components/ProfileButton.tsx
+++ b/src/components/Layout/components/ProfileButton.tsx
@@ -26,7 +26,6 @@ const ProfileButton = () => {
       className={styles.dialogWrapper}
       size="medium"
       placement="bottom-right"
-      fixed
     >
       <Dropdown.Trigger className={styles.profile}>
         <Icon icon="profileHeader" width={28} height={28} />

--- a/src/components/Tooltip/components/TooltipContent.tsx
+++ b/src/components/Tooltip/components/TooltipContent.tsx
@@ -2,9 +2,6 @@ import type { PropsWithChildren } from 'react';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import clsx from 'clsx';
 
-import { PORTAL_ID } from '@constants/portal';
-
-import Portal from '../../Portal';
 import { useTooltipContext } from '..';
 import * as styles from '../style.css';
 
@@ -28,23 +25,21 @@ const TooltipContent = ({ children }: PropsWithChildren) => {
   return (
     <>
       {isOpen && (
-        <Portal id={PORTAL_ID['TOOLTIP']}>
-          <div
-            ref={targetRef}
-            className={clsx(
-              styles.content({ hasArrow }),
-              hasArrow && placement && ARROW_STYLE[placement],
-              isTopMinimalTooltip && MARGIN_STYLE.MINIMAL,
-              isTopHighlightTooltip && MARGIN_STYLE.HIGHLIGHT,
-            )}
-            style={assignInlineVars({
-              [styles.top]: `${position.top}px`,
-              [styles.left]: `${position.left}px`,
-            })}
-          >
-            {children}
-          </div>
-        </Portal>
+        <div
+          ref={targetRef}
+          className={clsx(
+            styles.content({ hasArrow }),
+            hasArrow && placement && ARROW_STYLE[placement],
+            isTopMinimalTooltip && MARGIN_STYLE.MINIMAL,
+            isTopHighlightTooltip && MARGIN_STYLE.HIGHLIGHT,
+          )}
+          style={assignInlineVars({
+            [styles.top]: `${position.top}px`,
+            [styles.left]: `${position.left}px`,
+          })}
+        >
+          {children}
+        </div>
       )}
     </>
   );

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -6,6 +6,7 @@ import usePosition from '@hooks/usePosition';
 
 import TooltipContent from './components/TooltipContent';
 import TooltipTrigger from './components/TooltipTrigger';
+import * as styles from './style.css';
 
 const INIT_POSITION = { top: 0, left: 0 };
 
@@ -51,7 +52,9 @@ const TooltipRoot = ({
         onClose,
       }}
     >
-      <div ref={triggerRef}>{children}</div>
+      <div ref={triggerRef} className={styles.wrapper}>
+        {children}
+      </div>
     </TooltipContext.Provider>
   );
 };

--- a/src/components/Tooltip/style.css.ts
+++ b/src/components/Tooltip/style.css.ts
@@ -4,6 +4,10 @@ import { recipe } from '@vanilla-extract/recipes';
 import { sprinkles } from '@styles/sprinkles.css';
 import { COLORS, Z_INDEX } from '@styles/tokens';
 
+export const wrapper = style({
+  position: 'relative',
+});
+
 export const trigger = style({
   width: 'fit-content',
   height: 'fit-content',

--- a/src/constants/portal.ts
+++ b/src/constants/portal.ts
@@ -1,6 +1,4 @@
 export const PORTAL_ID = {
   MODAL: 'modal-root',
   TOAST: 'toast-root',
-  TOOLTIP: 'tooltip-root',
-  DROPDOWN: 'dropdown-root',
 } as const;

--- a/src/hooks/usePosition.ts
+++ b/src/hooks/usePosition.ts
@@ -25,6 +25,7 @@ const usePosition = <
   const ref = useRef<T>(null);
   const triggerRef = defaultTriggerRef || ref;
   const targetRef = useRef<U>(null);
+
   const [position, setPosition] = useState(POSITION);
 
   useEffect(() => {
@@ -32,23 +33,16 @@ const usePosition = <
       return;
     }
 
-    const {
-      x,
-      y,
-      bottom: triggerBottom,
-      width: triggerWidth,
-      height: triggerHeight,
-    } = triggerRef.current.getBoundingClientRect();
+    const { width: triggerWidth, height: triggerHeight } =
+      triggerRef.current.getBoundingClientRect();
     const { width: targetWidth } = targetRef.current.getBoundingClientRect();
 
-    const { scrollX, scrollY } = window;
+    const top = -triggerHeight;
+    const bottom = triggerHeight;
 
-    const top = y + scrollY - triggerHeight;
-    const bottom = !fixed ? y + scrollY + triggerHeight : triggerBottom;
-
-    const left = x + scrollX;
-    const center = left + triggerWidth / 2 - targetWidth / 2;
-    const right = left + triggerWidth - targetWidth;
+    const left = 0;
+    const center = triggerWidth / 2 - targetWidth / 2;
+    const right = triggerWidth - targetWidth;
 
     const CALCULATED_POSITION: Record<Placement, typeof POSITION> = {
       'top-left': { top, left },


### PR DESCRIPTION
## Summary

> 구현 내용 및 작업한 내역을 요약해서 적어주세요

- [x] [(usePosition): triggerRef 요소 기준으로 targetRef 위치값 계산](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/commit/4b5c018a617e9a66a7ad33851121598693d8d074)
- [x] [(Dropdown): viewport 변경에 따라 배치되도록 수정](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/commit/a023b36fa4bbe6ef19e3d6f83bac63159ef6da82)
- [x] [(Tooltip): portal 제거 및 스타일 수정](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/commit/4d3165581fd2d26190f43898624fd12611865aff)
- [x] [사용하지 않는 portal id 상수 제거](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/commit/400928ca6a52e09da7549c2283a9eb2c25affa0c)

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점을 적어주세요

https://github.com/YAPP-Github/23rd-Web-Team-2-FE/assets/76807107/069bc82b-d024-4506-913b-2201b103c043


- portal을 이용해 구현했을 때, viewport의 X축과 Y축이 변경되었을 때 추가로 대응해주어야 하는 문제가 있어 `Dropdown`, `Tooltip` 컴포넌트에는 portal을 제거했어요. `useClickAway`가 적용되어 있어 성능 문제는 없어보여요.
- `usePosition`: triggerRef 요소 기준으로 targetRef 위치값 계산해요.

## How To Test

> PR의 기능을 확인하는 방법을 상세하게 적어주세요
