### PR TITLE
[bug/BAR-237] 중복 폴더명에 대한 에러 핸들링

### DIFF
--- a/src/components/Modal/modals/EditFolder.tsx
+++ b/src/components/Modal/modals/EditFolder.tsx
@@ -20,7 +20,7 @@ const EditFolder = () => {
   const [value, setValue] = useState(folderName);
   const [errorMessage, setErrorMessage] = useState('');
 
-  const { mutateAsync } = useUpdateMemoFolder();
+  const { mutate } = useUpdateMemoFolder();
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setErrorMessage('');
@@ -30,11 +30,11 @@ const EditFolder = () => {
   const handleFolderNameEdit = async () => {
     if (value.length > 10) return setErrorMessage('10자 내로 입력해주세요!');
 
-    await mutateAsync(
+    mutate(
       { memoFolderId, folderName: value },
       {
-        onSuccess: async () => {
-          await queryClient.invalidateQueries({
+        onSuccess: () => {
+          queryClient.invalidateQueries({
             queryKey: ['memo-folders'],
           });
           closeModal();

--- a/src/components/Modal/modals/MakeFolder.tsx
+++ b/src/components/Modal/modals/MakeFolder.tsx
@@ -19,7 +19,7 @@ const MakeFolder = () => {
   const [value, setValue] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
 
-  const { mutateAsync } = usePostMemoFolders();
+  const { mutate } = usePostMemoFolders();
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setErrorMessage('');
@@ -29,7 +29,7 @@ const MakeFolder = () => {
   const handle만들기Click = async () => {
     if (value.length > 10) return setErrorMessage('10자 내로 입력해주세요!');
 
-    await mutateAsync(value, {
+    await mutate(value, {
       onSuccess: async () => {
         await queryClient.invalidateQueries({
           queryKey: ['memo-folders'],

--- a/src/components/Modal/modals/MakeFolder.tsx
+++ b/src/components/Modal/modals/MakeFolder.tsx
@@ -29,9 +29,9 @@ const MakeFolder = () => {
   const handle만들기Click = async () => {
     if (value.length > 10) return setErrorMessage('10자 내로 입력해주세요!');
 
-    await mutate(value, {
-      onSuccess: async () => {
-        await queryClient.invalidateQueries({
+    mutate(value, {
+      onSuccess: () => {
+        queryClient.invalidateQueries({
           queryKey: ['memo-folders'],
         });
         closeModal();


### PR DESCRIPTION
## Summary

> 구현 내용 및 작업한 내역을 요약해서 적어주세요

- [x] acaefffe6cf02c7c4bc6708add38edc880b02498 mutate를 사용하는 형태로 변경

## To Reviewers

https://tkdodo.eu/blog/mastering-mutations-in-react-query#mutate-or-mutateasync
async function이면 mutateAsync를 써야 되는줄 알았는데 그건 아닌 것 같더라고요. 이미 에러 핸들을 하기 때문에 mutate를 사용하는 형태로 변경합니다.

## How To Test

- 중복 폴더명 작성시 에러 메시지 노출
