### PR TITLE
[Fix/BAR-250] 폴더 삭제 에러 해결

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -94,8 +94,6 @@ export const http = {
     param?: ParamType,
     options?: AxiosRequestConfig,
   ): Promise<ResponseType> => instance.put(url, param, options),
-  delete: <ParamType, ResponseType>(
-    url: string,
-    param?: ParamType,
-  ): Promise<ResponseType> => instance.delete(url, param && param),
+  delete: <ResponseType>(url: string): Promise<ResponseType> =>
+    instance.delete(url),
 };

--- a/src/api/memoFolder/index.ts
+++ b/src/api/memoFolder/index.ts
@@ -27,8 +27,4 @@ export const deleteMemoFolders = ({
 }: {
   memoFolderId: number;
   deleteAllMemo: boolean;
-}) =>
-  http.delete(API_URL, {
-    memoFolderId,
-    deleteAllMemo,
-  });
+}) => http.delete(`${API_URL}/${memoFolderId}?deleteAllMemo=${deleteAllMemo}`);

--- a/src/api/memoFolder/mutations/useDeleteMemoFolder.ts
+++ b/src/api/memoFolder/mutations/useDeleteMemoFolder.ts
@@ -13,8 +13,12 @@ const useDeleteMemoFolder = () => {
 
   return useMutation({
     mutationFn: deleteMemoFolders,
-    onSuccess: () => {
-      showToast({ message: TOAST_MESSAGE.MEMOFOLDER.DELETE });
+    onSuccess: (data, variables) => {
+      showToast({
+        message: variables.deleteAllMemo
+          ? TOAST_MESSAGE.MEMOFOLDER.DELETE
+          : TOAST_MESSAGE.MEMOFOLDER.MOVE_TO_DEFAULT_FOLDER,
+      });
 
       queryClient.invalidateQueries({
         queryKey: MEMO_FOLDERS_KEY.all,

--- a/src/api/memoFolder/mutations/useDeleteMemoFolder.ts
+++ b/src/api/memoFolder/mutations/useDeleteMemoFolder.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { TOAST_MESSAGE } from '@constants/toast';
 import { useToastStore } from '@stores/toast';
 
 import { deleteMemoFolders } from '..';
@@ -13,7 +14,7 @@ const useDeleteMemoFolder = () => {
   return useMutation({
     mutationFn: deleteMemoFolders,
     onSuccess: () => {
-      showToast({ message: '선택한 폴더가 삭제되었어요' });
+      showToast({ message: TOAST_MESSAGE.MEMOFOLDER.DELETE });
 
       queryClient.invalidateQueries({
         queryKey: MEMO_FOLDERS_KEY.all,

--- a/src/api/memoFolder/mutations/useUpdateMemoFolder.ts
+++ b/src/api/memoFolder/mutations/useUpdateMemoFolder.ts
@@ -14,7 +14,7 @@ const useUpdateMemoFolder = () => {
   return useMutation({
     mutationFn: patchMemoFolders,
     onSuccess: () => {
-      showToast({ message: TOAST_MESSAGE.MEMOFOLDER.UPDATE });
+      showToast({ message: TOAST_MESSAGE.MEMOFOLDER.EDIT });
 
       queryClient.invalidateQueries({
         queryKey: MEMO_FOLDERS_KEY.all,

--- a/src/api/memoFolder/mutations/useUpdateMemoFolder.ts
+++ b/src/api/memoFolder/mutations/useUpdateMemoFolder.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { TOAST_MESSAGE } from '@constants/toast';
 import { useToastStore } from '@stores/toast';
 
 import { patchMemoFolders } from '..';
@@ -13,7 +14,7 @@ const useUpdateMemoFolder = () => {
   return useMutation({
     mutationFn: patchMemoFolders,
     onSuccess: () => {
-      showToast({ message: '폴더 이름이 수정되었어요' });
+      showToast({ message: TOAST_MESSAGE.MEMOFOLDER.UPDATE });
 
       queryClient.invalidateQueries({
         queryKey: MEMO_FOLDERS_KEY.all,

--- a/src/components/Button/components/TooltipButton/index.tsx
+++ b/src/components/Button/components/TooltipButton/index.tsx
@@ -1,5 +1,6 @@
 import { type HTMLAttributes, type PropsWithChildren } from 'react';
 
+import Button from '@components/Button';
 import Icon from '@components/Icon';
 import Tooltip from '@components/Tooltip';
 import { type Icons } from '@constants/icon';
@@ -9,6 +10,7 @@ import * as styles from './style.css';
 
 interface TooltipButtonProps extends HTMLAttributes<HTMLButtonElement> {
   isActive?: boolean;
+  isDropdown?: boolean;
   icon?: Icons;
   content: string;
 }
@@ -16,23 +18,30 @@ interface TooltipButtonProps extends HTMLAttributes<HTMLButtonElement> {
 const TooltipButton = ({
   children,
   isActive = false,
+  isDropdown = false,
   icon,
   content,
   ...props
 }: PropsWithChildren<TooltipButtonProps>) => {
+  const iconComponent = icon ? (
+    <Icon
+      className={styles.hover}
+      icon={icon}
+      color={isActive ? COLORS['Blue/Default'] : COLORS['Grey/300']}
+    />
+  ) : (
+    <>{children}</>
+  );
+
+  const buttonComponent = isDropdown ? (
+    iconComponent
+  ) : (
+    <Button {...props}>{iconComponent}</Button>
+  );
+
   return (
     <Tooltip placement="top-center">
-      <Tooltip.Trigger {...props}>
-        {icon ? (
-          <Icon
-            icon={icon}
-            className={styles.hover}
-            color={isActive ? COLORS['Blue/Default'] : COLORS['Grey/300']}
-          />
-        ) : (
-          <>{children}</>
-        )}
-      </Tooltip.Trigger>
+      <Tooltip.Trigger>{buttonComponent}</Tooltip.Trigger>
       <Tooltip.Content>{content}</Tooltip.Content>
     </Tooltip>
   );

--- a/src/components/Button/style.css.ts
+++ b/src/components/Button/style.css.ts
@@ -6,6 +6,10 @@ import { COLORS } from '@styles/tokens';
 export const button = recipe({
   base: {
     whiteSpace: 'nowrap',
+
+    ':disabled': {
+      cursor: 'not-allowed',
+    },
   },
   variants: {
     state: {

--- a/src/components/Button/style.css.ts
+++ b/src/components/Button/style.css.ts
@@ -6,10 +6,6 @@ import { COLORS } from '@styles/tokens';
 export const button = recipe({
   base: {
     whiteSpace: 'nowrap',
-
-    ':disabled': {
-      cursor: 'not-allowed',
-    },
   },
   variants: {
     state: {

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -64,9 +64,7 @@ const CardMenu = ({ children }: PropsWithChildren) => {
 
   return (
     <>
-      {!defaultIsVisibleMenu ? (
-        isVisibleMenu && <div className={styles.menu}>{children}</div>
-      ) : (
+      {(defaultIsVisibleMenu || isVisibleMenu) && (
         <div className={styles.menu}>{children}</div>
       )}
     </>

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -16,10 +16,11 @@ interface CardProps {
     | 'grey'
     | 'white';
   className?: string;
+  defaultIsVisibleMenu?: boolean;
   onBlur?: VoidFunction;
 }
 
-interface CardContextProps {
+interface CardContextProps extends Pick<CardProps, 'defaultIsVisibleMenu'> {
   isVisibleMenu: boolean;
 }
 
@@ -30,6 +31,7 @@ export const CardContext = createContext<CardContextProps>({
 const CardRoot = ({
   children,
   className,
+  defaultIsVisibleMenu = false,
   color = 'white',
 }: PropsWithChildren<CardProps>) => {
   const {
@@ -39,11 +41,17 @@ const CardRoot = ({
   } = useDisclosure();
 
   return (
-    <CardContext.Provider value={{ isVisibleMenu: isVisible }}>
+    <CardContext.Provider
+      value={{ isVisibleMenu: isVisible, defaultIsVisibleMenu }}
+    >
       <li
         className={clsx(styles.wrapper({ color }), className)}
-        onMouseEnter={onShow}
-        onMouseLeave={onHide}
+        onMouseEnter={() => {
+          !defaultIsVisibleMenu && onShow();
+        }}
+        onMouseLeave={() => {
+          !defaultIsVisibleMenu && onHide();
+        }}
       >
         {children}
       </li>
@@ -52,9 +60,17 @@ const CardRoot = ({
 };
 
 const CardMenu = ({ children }: PropsWithChildren) => {
-  const { isVisibleMenu } = useContext(CardContext);
+  const { isVisibleMenu, defaultIsVisibleMenu } = useContext(CardContext);
 
-  return <>{isVisibleMenu && <div className={styles.menu}>{children}</div>}</>;
+  return (
+    <>
+      {!defaultIsVisibleMenu ? (
+        isVisibleMenu && <div className={styles.menu}>{children}</div>
+      ) : (
+        <div className={styles.menu}>{children}</div>
+      )}
+    </>
+  );
 };
 
 const CardHeader = ({ children }: PropsWithChildren) => {

--- a/src/components/Dropdown/FolderDropdown/index.tsx
+++ b/src/components/Dropdown/FolderDropdown/index.tsx
@@ -45,7 +45,7 @@ const FolderDropdown = ({
   return (
     <Dropdown size="medium" placement="bottom-center">
       <Dropdown.Trigger>
-        <TooltipButton icon="bookmark" content="저장" />
+        <TooltipButton icon="bookmark" content="저장" isDropdown />
       </Dropdown.Trigger>
       <Dropdown.List>
         {memoFolders.map(({ id, name }) => (

--- a/src/components/Dropdown/MenuDropdown/index.tsx
+++ b/src/components/Dropdown/MenuDropdown/index.tsx
@@ -11,7 +11,7 @@ const MenuDropdown = ({ onEdit, onDelete }: MenuDropdownProps) => {
   return (
     <Dropdown size="small" placement="bottom-right">
       <Dropdown.Trigger>
-        <TooltipButton icon="menu" content="더보기" />
+        <TooltipButton icon="menu" content="더보기" isDropdown />
       </Dropdown.Trigger>
       <Dropdown.List>
         {onEdit && <Dropdown.Item onClick={onEdit}>수정하기</Dropdown.Item>}

--- a/src/components/Dropdown/components/DropdownItem.tsx
+++ b/src/components/Dropdown/components/DropdownItem.tsx
@@ -13,11 +13,18 @@ const DropdownItem = ({
   className,
   ...props
 }: PropsWithChildren<DropdownItemProps>) => {
-  const { size } = useDropdownContext();
+  const { size, onClose } = useDropdownContext();
 
   return (
     <li className={className}>
-      <Button {...props} className={clsx(styles.menuItem({ size }))}>
+      <Button
+        {...props}
+        onClick={(e) => {
+          props.onClick && props.onClick(e);
+          onClose();
+        }}
+        className={clsx(styles.menuItem({ size }))}
+      >
         {children}
       </Button>
     </li>

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -8,7 +8,7 @@ import {
 import clsx from 'clsx';
 
 import useClickAway from '@hooks/useClickAway';
-import useDisclosure from '@hooks/useDisclosure';
+import useDisclosure, { type UseDisclosure } from '@hooks/useDisclosure';
 import usePosition from '@hooks/usePosition';
 
 import DropdownItem from './components/DropdownItem';
@@ -19,7 +19,8 @@ import * as styles from './style.css';
 
 const INIT_POSITION = { top: 0, left: 0 };
 
-interface DropdownContextProps {
+interface DropdownContextProps
+  extends Pick<UseDisclosure, 'isOpen' | 'onClose' | 'onToggle'> {
   /** dropdown menulist 크기 */
   size?: 'small' | 'medium';
   /** dropdown menulist 위치 */
@@ -28,10 +29,6 @@ interface DropdownContextProps {
   position: typeof INIT_POSITION;
   /** dropdown menulist 요소의 ref 객체  */
   targetRef: RefObject<HTMLUListElement>;
-  /** dropdown menulist 열림, 닫힘 상태 */
-  isOpen: boolean;
-  /** dropdown trigger toggle 함수 */
-  onToggle: () => void;
 }
 
 interface DropdownRootProps
@@ -68,6 +65,7 @@ const DropdownRoot = ({
         position,
         targetRef,
         isOpen,
+        onClose,
         onToggle,
       }}
     >

--- a/src/components/Modal/modals/MakeFolder.tsx
+++ b/src/components/Modal/modals/MakeFolder.tsx
@@ -26,7 +26,7 @@ const MakeFolder = () => {
     setValue(e.target.value);
   };
 
-  const handle만들기Click = async () => {
+  const handleMakeFolderButtonClick = async () => {
     if (value.length > 10) return setErrorMessage('10자 내로 입력해주세요!');
 
     mutate(value, {
@@ -91,7 +91,7 @@ const MakeFolder = () => {
             [styles.buttonColor]: COLORS['Grey/White'],
             [styles.buttonBackgroundColor]: COLORS['Blue/Default'],
           })}
-          onClick={handle만들기Click}
+          onClick={handleMakeFolderButtonClick}
         >
           만들기
         </Button>

--- a/src/components/Modal/style.css.ts
+++ b/src/components/Modal/style.css.ts
@@ -268,17 +268,18 @@ export const makeFolderInputWrapper = style({
 });
 
 export const makeFolderInput = style({
+  width: '100%',
+  height: '48px',
   padding: '12px 16px',
   color: COLORS['Grey/600'],
-  backgroundColor: '#f0f0f0',
+  backgroundColor: COLORS['Grey/100'],
   borderRadius: '8px',
-  height: '48px',
-  width: '100%',
 });
 
 export const errorInput = style({
   border: `1.5px solid ${COLORS['Red']}`,
 });
+
 export const makeFolderButtonWrapper = style({
   paddingTop: '16px',
 });

--- a/src/constants/spellCheck.ts
+++ b/src/constants/spellCheck.ts
@@ -3,8 +3,3 @@ export const SPELLCHECK_TYPE = {
   space: '띄어쓰기',
   doubt: '표준어의심',
 } as const;
-
-export const SPELLCHECK_STATE_MESSAGE = {
-  SUCCESS: '맞춤법 검사가 완료되었어요. 올바른 문장을 확인해보세요!',
-  ERROR: '지금은 맞춤법 검사가 힘들어요. 잠시 후에 다시 시도해주세요.',
-} as const;

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -4,3 +4,18 @@ export const TOAST_DURATION_TIME = {
 } as const;
 
 export const TOAST_TRANSITION_DURATION = 400;
+
+export const TOAST_MESSAGE = {
+  CARD: {
+    COPY: '글이 복사되었어요. 원하는 곳에 붙여넣기(Ctrl+V)를 해주세요!',
+    SAVE: '글이 저장됐어요.',
+  },
+  SPELLCHECK: {
+    SUCCESS: '맞춤법 검사가 완료되었어요. 올바른 문장을 확인해보세요!',
+    ERROR: '지금은 맞춤법 검사가 힘들어요. 잠시 후에 다시 시도해주세요.',
+  },
+  MEMOFOLDER: {
+    UPDATE: '폴더 이름이 수정되었어요',
+    DELETE: '선택한 폴더가 삭제되었어요',
+  },
+};

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -8,14 +8,17 @@ export const TOAST_TRANSITION_DURATION = 400;
 export const TOAST_MESSAGE = {
   CARD: {
     COPY: '글이 복사되었어요. 원하는 곳에 붙여넣기(Ctrl+V)를 해주세요!',
-    SAVE: '글이 저장됐어요.',
+    SAVE: '글이 저장되었어요.',
+    EDIT: '글이 수정됐어요.',
+    DELETE: '글이 삭제됐어요.',
   },
   SPELLCHECK: {
     SUCCESS: '맞춤법 검사가 완료되었어요. 올바른 문장을 확인해보세요!',
     ERROR: '지금은 맞춤법 검사가 힘들어요. 잠시 후에 다시 시도해주세요.',
   },
   MEMOFOLDER: {
-    UPDATE: '폴더 이름이 수정되었어요',
-    DELETE: '선택한 폴더가 삭제되었어요',
+    EDIT: '폴더 이름이 수정됐어요.',
+    DELETE: '폴더와 글이 모두 삭제됐어요.',
+    MOVE_TO_DEFAULT_FOLDER: '글이 모두 기본 폴더로 이동됐어요.',
   },
 };

--- a/src/domain/landing/components/LandingCard.tsx
+++ b/src/domain/landing/components/LandingCard.tsx
@@ -3,7 +3,7 @@ import Card from '@components/Card';
 import { CATEGORY_COLOR } from '@constants/config';
 import { CATEGORY } from '@domain/참고하는/models';
 import { type ReferContent } from '@domain/참고하는/types';
-import { getNumToK } from '@domain/참고하는/utils';
+import { formatNumberToCompact } from '@domain/참고하는/utils';
 
 import * as styles from '../style.css';
 
@@ -24,8 +24,8 @@ const LandingCard = ({ data }: LandingCardProps) => {
       </Card.Header>
       <Card.Body className={styles.cardBody}>{content}</Card.Body>
       <Card.Footer>
-        복사 <span>{getNumToK(copiedCount)}</span> • 저장{' '}
-        <span>{getNumToK(savedCount)}</span>
+        복사 <span>{formatNumberToCompact(copiedCount)}</span> • 저장{' '}
+        <span>{formatNumberToCompact(savedCount)}</span>
       </Card.Footer>
     </Card>
   );

--- a/src/domain/landing/components/LandingCard.tsx
+++ b/src/domain/landing/components/LandingCard.tsx
@@ -24,8 +24,14 @@ const LandingCard = ({ data }: LandingCardProps) => {
       </Card.Header>
       <Card.Body className={styles.cardBody}>{content}</Card.Body>
       <Card.Footer>
-        복사 <span>{formatNumberToCompact(copiedCount)}</span> • 저장{' '}
-        <span>{formatNumberToCompact(savedCount)}</span>
+        복사&nbsp;
+        <span className={styles.count}>
+          {formatNumberToCompact(copiedCount)}
+        </span>
+        &nbsp; • 저장&nbsp;
+        <span className={styles.count}>
+          {formatNumberToCompact(savedCount)}
+        </span>
       </Card.Footer>
     </Card>
   );

--- a/src/domain/landing/style.css.ts
+++ b/src/domain/landing/style.css.ts
@@ -174,3 +174,9 @@ export const buttonText = style({
   height: '58px',
   paddingTop: '17px',
 });
+
+export const count = style({
+  fontWeight: 500,
+  fontSize: '14px',
+  color: COLORS['Grey/500'],
+});

--- a/src/domain/끄적이는/components/Card/History/index.tsx
+++ b/src/domain/끄적이는/components/Card/History/index.tsx
@@ -6,6 +6,7 @@ import TooltipButton from '@components/Button/components/TooltipButton';
 import Card from '@components/Card';
 import FolderDropdown from '@components/Dropdown/FolderDropdown';
 import MenuDropdown from '@components/Dropdown/MenuDropdown';
+import { TOAST_MESSAGE } from '@constants/toast';
 import useDeleteTemporalMemo from '@domain/끄적이는/mutations/useDeleteTemporalMemo';
 import useEditTemporalMemo from '@domain/끄적이는/mutations/useEditTemporalMemo';
 import useSaveTemporalMemo from '@domain/끄적이는/mutations/useSaveTemporalMemo';
@@ -46,9 +47,8 @@ const WriteHistoryCard = ({
 
   const handleCopyClick = () => {
     navigator.clipboard.writeText(content);
-    showToast({
-      message: '문장이 복사되었어요. 원하는 곳에 붙여넣기(Ctrl+V)를 해주세요!',
-    });
+
+    showToast({ message: TOAST_MESSAGE.CARD.COPY });
   };
 
   const handleEditCompleteClick = () => {

--- a/src/domain/끄적이는/components/Card/Today/index.tsx
+++ b/src/domain/끄적이는/components/Card/Today/index.tsx
@@ -9,6 +9,7 @@ import Card from '@components/Card';
 import FolderDropdown from '@components/Dropdown/FolderDropdown';
 import MenuDropdown from '@components/Dropdown/MenuDropdown';
 import SkeletonContent from '@components/Loading/Skeleton/SkeletonContent';
+import { TOAST_MESSAGE } from '@constants/toast';
 import useDeleteTemporalMemo from '@domain/끄적이는/mutations/useDeleteTemporalMemo';
 import useEditTemporalMemo from '@domain/끄적이는/mutations/useEditTemporalMemo';
 import useSaveTemporalMemo from '@domain/끄적이는/mutations/useSaveTemporalMemo';
@@ -64,9 +65,8 @@ const WriteTodayCard = ({
 
   const handleCopyClick = () => {
     navigator.clipboard.writeText(memo.content);
-    showToast({
-      message: '문장이 복사되었어요. 원하는 곳에 붙여넣기(Ctrl+V)를 해주세요!',
-    });
+
+    showToast({ message: TOAST_MESSAGE.CARD.COPY });
   };
 
   //TODO: 밸리데이션 추가
@@ -81,7 +81,7 @@ const WriteTodayCard = ({
 
   if (isEditMode) {
     return (
-      <Card color="blue">
+      <Card isHoverMenu={false} color="blue">
         <Card.Header>
           {dayjs(memo.createdAt).locale('ko').format('a h:mm')}
           <Button className={styles.editCompleteButton} onClick={handleUpdate}>
@@ -96,7 +96,7 @@ const WriteTodayCard = ({
   }
 
   return (
-    <Card color="blue">
+    <Card isHoverMenu={false} color="blue">
       {!isSuccessSpellCheck && (
         <Card.Menu>
           <TooltipButton

--- a/src/domain/끄적이는/components/Card/Today/index.tsx
+++ b/src/domain/끄적이는/components/Card/Today/index.tsx
@@ -81,7 +81,7 @@ const WriteTodayCard = ({
 
   if (isEditMode) {
     return (
-      <Card isHoverMenu={false} color="blue">
+      <Card color="blue" defaultIsVisibleMenu>
         <Card.Header>
           {dayjs(memo.createdAt).locale('ko').format('a h:mm')}
           <Button className={styles.editCompleteButton} onClick={handleUpdate}>
@@ -96,7 +96,7 @@ const WriteTodayCard = ({
   }
 
   return (
-    <Card isHoverMenu={false} color="blue">
+    <Card color="blue" defaultIsVisibleMenu>
       {!isSuccessSpellCheck && (
         <Card.Menu>
           <TooltipButton

--- a/src/domain/끄적이는/components/Today/components/SpellCheckCard/index.tsx
+++ b/src/domain/끄적이는/components/Today/components/SpellCheckCard/index.tsx
@@ -6,6 +6,7 @@ import FolderDropdown, {
   type FolderDropdownType,
 } from '@components/Dropdown/FolderDropdown';
 import { type SPELLCHECK_TYPE } from '@constants/spellCheck';
+import { TOAST_MESSAGE } from '@constants/toast';
 import { useToastStore } from '@stores/toast';
 
 import SpellCheckNotice from '../SpellCheckNotice';
@@ -64,9 +65,8 @@ const SpellCheckCard = ({
 
   const handleCopyClick = () => {
     navigator.clipboard.writeText(spellCheckResult.correction);
-    showToast({
-      message: '문장이 복사되었어요. 원하는 곳에 붙여넣기(Ctrl+V)를 해주세요!',
-    });
+
+    showToast({ message: TOAST_MESSAGE.CARD.COPY });
   };
 
   return (

--- a/src/domain/끄적이는/mutations/useSaveTemporalMemo.ts
+++ b/src/domain/끄적이는/mutations/useSaveTemporalMemo.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { http } from '@api/http';
+import { TOAST_MESSAGE } from '@constants/toast';
 import { useToastStore } from '@stores/toast';
 
 import { TemporalMemoQueryKeys } from '../constants/queryKeys';
@@ -26,7 +27,7 @@ const useSaveTemporalMemo = () => {
     mutationFn: saveTemporalMemo,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: TemporalMemoQueryKeys.all });
-      showToast({ message: '글이 저장됐어요.' });
+      showToast({ message: TOAST_MESSAGE.CARD.SAVE });
     },
   });
 };

--- a/src/domain/저장하는/components/ArchiveFolder/index.tsx
+++ b/src/domain/저장하는/components/ArchiveFolder/index.tsx
@@ -35,7 +35,7 @@ const ArchiveFolder = ({ folders }: ArchiveFolderProps) => {
             })}
           >
             <span>{data?.nickname}님의 폴더</span>
-            <span className={styles.tag}>기본</span>
+            <span className={styles.badge}>기본</span>
           </Link>
         ) : (
           <FolderItem key={folder.id} folder={folder} />

--- a/src/domain/저장하는/components/ArchiveFolder/style.css.ts
+++ b/src/domain/저장하는/components/ArchiveFolder/style.css.ts
@@ -16,15 +16,17 @@ export const folder = style({
 
 export const userFolder = recipe({
   base: [
-    sprinkles({ typography: '16/Title/Bold' }),
+    sprinkles({ typography: '16/Title/Medium' }),
     utils.flexAlignCenter,
     {
       gap: '5px',
-      padding: '8px 20px',
+      padding: '14px 20px',
       borderRadius: '8px',
       transition: 'all 100ms ease-in-out',
 
       ':hover': {
+        fontWeight: 700,
+        color: COLORS['Grey/900'],
         backgroundColor: COLORS['Grey/100'],
       },
     },
@@ -32,7 +34,9 @@ export const userFolder = recipe({
   variants: {
     isActive: {
       true: {
-        backgroundColor: COLORS['Grey/100'],
+        fontWeight: 700,
+        color: COLORS['Blue/Default'],
+        backgroundColor: COLORS['Grey/White'],
       },
       false: {
         backgroundColor: COLORS['Grey/White'],
@@ -61,7 +65,12 @@ export const createFolderButton = style([
   {
     width: '100%',
     gap: '4px',
-    padding: '8px 20px',
+    padding: '10px 20px',
+    borderRadius: '8px',
     color: COLORS['Grey/400'],
+
+    ':hover': {
+      backgroundColor: COLORS['Grey/100'],
+    },
   },
 ]);

--- a/src/domain/저장하는/components/ArchiveFolder/style.css.ts
+++ b/src/domain/저장하는/components/ArchiveFolder/style.css.ts
@@ -41,10 +41,10 @@ export const userFolder = recipe({
   },
 });
 
-export const tag = style([
+export const badge = style([
   sprinkles({ typography: '11/Caption/Medium' }),
   {
-    padding: '6px',
+    padding: '3px 6px',
     borderRadius: '100px',
     color: COLORS['Blue/Default'],
     backgroundColor: COLORS['Blue/Light'],

--- a/src/domain/저장하는/components/ArchivedCard/index.tsx
+++ b/src/domain/저장하는/components/ArchivedCard/index.tsx
@@ -73,8 +73,14 @@ const ArchivedCard = ({ folderId, card }: ArchivedCardProps) => {
         </Card.Header>
         <Card.Body>{card.content}</Card.Body>
         <Card.Footer>
-          복사 <span>{formatNumberToCompact(card.copiedCount)}</span> • 저장{' '}
-          <span>{formatNumberToCompact(card.savedCount)}</span>
+          복사&nbsp;
+          <span className={styles.count}>
+            {formatNumberToCompact(card.copiedCount)}
+          </span>
+          &nbsp; • 저장&nbsp;
+          <span className={styles.count}>
+            {formatNumberToCompact(card.savedCount)}
+          </span>
         </Card.Footer>
       </Card>
     );

--- a/src/domain/저장하는/components/ArchivedCard/index.tsx
+++ b/src/domain/저장하는/components/ArchivedCard/index.tsx
@@ -6,10 +6,11 @@ import TooltipButton from '@components/Button/components/TooltipButton';
 import Card from '@components/Card';
 import MenuDropdown from '@components/Dropdown/MenuDropdown';
 import { CATEGORY_COLOR } from '@constants/config';
+import { TOAST_MESSAGE } from '@constants/toast';
 import EditInput from '@domain/끄적이는/components/EditInput';
 import useDeleteArchives from '@domain/저장하는/mutations/useDeleteArchives';
 import useUpdateArchives from '@domain/저장하는/mutations/useUpdateArchives';
-import { getNumToK } from '@domain/참고하는/utils';
+import { formatNumberToCompact } from '@domain/참고하는/utils';
 import { useInput } from '@hooks/useInput';
 import { useToastStore } from '@stores/toast';
 
@@ -25,20 +26,18 @@ const ArchivedCard = ({ folderId, card }: ArchivedCardProps) => {
   const { showToast } = useToastStore();
 
   const [isEditMode, setIsEditMode] = useState(false);
-
-  const { mutate: updateArchivedCardContent } = useUpdateArchives(folderId);
-  const { mutate: deleteArchivedCard } = useDeleteArchives(folderId);
-
   const editedInputProps = useInput({
     id: 'edit-input',
     defaultValue: card.content,
   });
 
+  const { mutate: updateArchivedCardContent } = useUpdateArchives(folderId);
+  const { mutate: deleteArchivedCard } = useDeleteArchives(folderId);
+
   const handleCopyClick = (content: ArchiveCard['content']) => {
     navigator.clipboard.writeText(content);
-    showToast({
-      message: '문장이 복사되었어요. 원하는 곳에 붙여넣기(Ctrl+V)를 해주세요!',
-    });
+
+    showToast({ message: TOAST_MESSAGE.CARD.COPY });
   };
 
   const handleEditClick = () => {
@@ -74,8 +73,8 @@ const ArchivedCard = ({ folderId, card }: ArchivedCardProps) => {
         </Card.Header>
         <Card.Body>{card.content}</Card.Body>
         <Card.Footer>
-          복사 <span>{getNumToK(card.copiedCount)}</span> • 저장{' '}
-          <span>{getNumToK(card.savedCount)}</span>
+          복사 <span>{formatNumberToCompact(card.copiedCount)}</span> • 저장{' '}
+          <span>{formatNumberToCompact(card.savedCount)}</span>
         </Card.Footer>
       </Card>
     );

--- a/src/domain/저장하는/components/ArchivedCard/style.css.ts
+++ b/src/domain/저장하는/components/ArchivedCard/style.css.ts
@@ -20,3 +20,9 @@ export const editButton = style([
     },
   },
 ]);
+
+export const count = style({
+  fontWeight: 500,
+  fontSize: '14px',
+  color: COLORS['Grey/500'],
+});

--- a/src/domain/저장하는/components/DeleteFolderModal/index.tsx
+++ b/src/domain/저장하는/components/DeleteFolderModal/index.tsx
@@ -14,16 +14,11 @@ const DeleteFolderModal = () => {
   const { closeModal, memoFolderId } = useModalStore();
   const { mutate: deleteFolder } = useDeleteMemoFolder();
 
-  const handleAllFolderDelete = () => {
-    deleteFolder({ memoFolderId, deleteAllMemo: true });
-    closeModal();
-  };
-
-  const handleCardMove = () => {
-    deleteFolder({ memoFolderId, deleteAllMemo: false });
+  const handleFolderDelete = (deleteAllMemo: boolean) => {
+    deleteFolder({ memoFolderId, deleteAllMemo });
     closeModal();
 
-    router.push(ROUTES.ARCHIVE);
+    router.replace(ROUTES.ARCHIVE);
   };
 
   return (
@@ -41,11 +36,15 @@ const DeleteFolderModal = () => {
           state="default"
           size="M"
           className={styles.button}
-          onClick={handleAllFolderDelete}
+          onClick={() => handleFolderDelete(true)}
         >
           모두 삭제하기
         </Button>
-        <Button state="enabled" size="M" onClick={handleCardMove}>
+        <Button
+          state="enabled"
+          size="M"
+          onClick={() => handleFolderDelete(false)}
+        >
           기본 폴더로 이동하기
         </Button>
       </ModalContainer.Footer>

--- a/src/domain/저장하는/components/DeleteFolderModal/index.tsx
+++ b/src/domain/저장하는/components/DeleteFolderModal/index.tsx
@@ -1,11 +1,16 @@
+import { useRouter } from 'next/router';
+
 import useDeleteMemoFolder from '@api/memoFolder/mutations/useDeleteMemoFolder';
 import Button from '@components/Button';
 import ModalContainer from '@components/Modal/components/ModalContainer';
+import { ROUTES } from '@constants/routes';
 import { useModalStore } from '@stores/modal';
 
 import * as styles from './style.css';
 
 const DeleteFolderModal = () => {
+  const router = useRouter();
+
   const { closeModal, memoFolderId } = useModalStore();
   const { mutate: deleteFolder } = useDeleteMemoFolder();
 
@@ -17,6 +22,8 @@ const DeleteFolderModal = () => {
   const handleCardMove = () => {
     deleteFolder({ memoFolderId, deleteAllMemo: false });
     closeModal();
+
+    router.push(ROUTES.ARCHIVE);
   };
 
   return (

--- a/src/domain/저장하는/components/Folder/style.css.ts
+++ b/src/domain/저장하는/components/Folder/style.css.ts
@@ -15,9 +15,11 @@ export const folderButton = recipe({
       justifyContent: 'space-between',
       borderRadius: '8px',
       transition: 'all 100ms ease-in-out',
-      paddingRight: '8px',
+      paddingRight: '12px',
 
       ':hover': {
+        fontWeight: 700,
+        color: COLORS['Grey/900'],
         backgroundColor: COLORS['Grey/100'],
       },
     },
@@ -25,7 +27,9 @@ export const folderButton = recipe({
   variants: {
     isActive: {
       true: {
-        backgroundColor: COLORS['Grey/100'],
+        fontWeight: 700,
+        color: COLORS['Blue/Default'],
+        backgroundColor: COLORS['Grey/White'],
       },
       false: {
         backgroundColor: COLORS['Grey/White'],
@@ -37,5 +41,5 @@ export const folderButton = recipe({
 export const folderName = style({
   display: 'inline-block',
   width: '100%',
-  padding: '11px 0 11px 20px',
+  padding: '14px 0 14px 20px',
 });

--- a/src/domain/저장하는/mutations/useDeleteArchives.ts
+++ b/src/domain/저장하는/mutations/useDeleteArchives.ts
@@ -1,9 +1,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { TOAST_MESSAGE } from '@constants/toast';
+import { useToastStore } from '@stores/toast';
+
 import archiveApi from '../api';
 import { ARCHIVES_QUERY_KEY } from '../constants/queryKeys';
 
 const useDeleteArchives = (folderId: number) => {
+  const { showToast } = useToastStore();
+
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -12,6 +17,8 @@ const useDeleteArchives = (folderId: number) => {
       queryClient.invalidateQueries({
         queryKey: ARCHIVES_QUERY_KEY.item([folderId]),
       });
+
+      showToast({ message: TOAST_MESSAGE.CARD.DELETE });
     },
   });
 };

--- a/src/domain/참고하는/components/참고하는TemplateCard.css.ts
+++ b/src/domain/참고하는/components/참고하는TemplateCard.css.ts
@@ -1,6 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
 import { sprinkles } from '@styles/sprinkles.css';
+import { COLORS } from '@styles/tokens';
 
 export const wrapper = style([
   sprinkles({
@@ -15,3 +16,9 @@ export const wrapper = style([
     padding: '28px 32px 20px',
   },
 ]);
+
+export const count = style({
+  fontWeight: 500,
+  fontSize: '14px',
+  color: COLORS['Grey/500'],
+});

--- a/src/domain/참고하는/components/참고하는TemplateCard.tsx
+++ b/src/domain/참고하는/components/참고하는TemplateCard.tsx
@@ -1,5 +1,3 @@
-import { useQueryClient } from '@tanstack/react-query';
-
 import { type Folder } from '@api/memoFolder/types';
 import Badge from '@components/Badge';
 import TooltipButton from '@components/Button/components/TooltipButton';
@@ -9,8 +7,7 @@ import { CATEGORY_COLOR } from '@constants/config';
 import * as styles from '@domain/참고하는/components/참고하는TemplateCard.css';
 import { CATEGORY } from '@domain/참고하는/models';
 import { type ReferContent } from '@domain/참고하는/types';
-import { getNumToK } from '@domain/참고하는/utils';
-import { useToastStore } from '@stores/toast';
+import { formatNumberToCompact } from '@domain/참고하는/utils';
 
 import useCopyTemplate from '../queries/useCopyTemplate';
 import useDeleteTemplate from '../queries/useDeleteTemplate';
@@ -35,28 +32,16 @@ const 참고하는TemplateCard = ({
     isArchived,
   } = data;
 
-  const { showToast } = useToastStore();
-
-  const queryClient = useQueryClient();
-  const { mutateAsync: copyTemplate } = useCopyTemplate();
+  const { mutate: copyTemplate } = useCopyTemplate();
   const { mutate: saveTemplate } = useSaveTemplate();
   const { mutate: deleteTemplate } = useDeleteTemplate();
 
   const categoryNameKr = CATEGORY[category];
 
   const handleCopyClick = async () => {
-    await copyTemplate(templateId, {
-      onSuccess: () => {
-        queryClient.invalidateQueries({
-          queryKey: ['templates'],
-        }),
-          navigator.clipboard.writeText(content);
-        showToast({
-          message:
-            '글이 복사되었어요. 원하는 곳에 붙여넣기(Ctrl+V)를 해주세요!',
-        });
-      },
-    });
+    copyTemplate(templateId);
+
+    navigator.clipboard.writeText(content);
   };
 
   const handleFolderClick = (memoFolderId: Folder['id']) => {
@@ -84,8 +69,8 @@ const 참고하는TemplateCard = ({
       </Card.Header>
       <Card.Body>{content}</Card.Body>
       <Card.Footer>
-        복사 <span>{getNumToK(copiedCount)}</span> • 저장{' '}
-        <span>{getNumToK(savedCount)}</span>
+        복사 <span>{formatNumberToCompact(copiedCount)}</span> • 저장{' '}
+        <span>{formatNumberToCompact(savedCount)}</span>
       </Card.Footer>
     </Card>
   );

--- a/src/domain/참고하는/components/참고하는TemplateCard.tsx
+++ b/src/domain/참고하는/components/참고하는TemplateCard.tsx
@@ -69,8 +69,14 @@ const 참고하는TemplateCard = ({
       </Card.Header>
       <Card.Body>{content}</Card.Body>
       <Card.Footer>
-        복사 <span>{formatNumberToCompact(copiedCount)}</span> • 저장{' '}
-        <span>{formatNumberToCompact(savedCount)}</span>
+        복사&nbsp;
+        <span className={styles.count}>
+          {formatNumberToCompact(copiedCount)}
+        </span>
+        &nbsp; • 저장&nbsp;
+        <span className={styles.count}>
+          {formatNumberToCompact(savedCount)}
+        </span>
       </Card.Footer>
     </Card>
   );

--- a/src/domain/참고하는/queries/useCopyTemplate.ts
+++ b/src/domain/참고하는/queries/useCopyTemplate.ts
@@ -1,10 +1,27 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { TOAST_MESSAGE } from '@constants/toast';
+import { useToastStore } from '@stores/toast';
 
 import { patchTemplateCopyCount } from '../api';
 
-const useCopyTemplate = () =>
-  useMutation({
+const useCopyTemplate = () => {
+  const queryClient = useQueryClient();
+
+  const { showToast } = useToastStore();
+
+  return useMutation({
     mutationFn: patchTemplateCopyCount,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['templates'],
+      });
+
+      showToast({
+        message: TOAST_MESSAGE.CARD.COPY,
+      });
+    },
   });
+};
 
 export default useCopyTemplate;

--- a/src/domain/참고하는/queries/useSaveTemplate.ts
+++ b/src/domain/참고하는/queries/useSaveTemplate.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { TOAST_MESSAGE } from '@constants/toast';
 import { useToastStore } from '@stores/toast';
 
 import { postSaveTemplate } from '../api';
@@ -15,7 +16,7 @@ const useSaveTemplate = () => {
       queryClient.invalidateQueries({
         queryKey: ['templates'],
       });
-      showToast({ message: '글이 저장됐어요.' });
+      showToast({ message: TOAST_MESSAGE.CARD.SAVE });
     },
   });
 };

--- a/src/domain/참고하는/utils/index.ts
+++ b/src/domain/참고하는/utils/index.ts
@@ -1,4 +1,4 @@
-export const getNumToK = (num: number) => {
+export const formatNumberToCompact = (num: number) => {
   const formatter = new Intl.NumberFormat('en', { notation: 'compact' });
   return formatter.format(num);
 };

--- a/src/hooks/useDisclosure.ts
+++ b/src/hooks/useDisclosure.ts
@@ -19,3 +19,5 @@ const useDisclosure = () => {
 };
 
 export default useDisclosure;
+
+export type UseDisclosure = ReturnType<typeof useDisclosure>;

--- a/src/queries/usePostSpellCheck.ts
+++ b/src/queries/usePostSpellCheck.ts
@@ -1,7 +1,7 @@
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
 import { type AxiosError } from 'axios';
 
-import { SPELLCHECK_STATE_MESSAGE } from '@constants/spellCheck';
+import { TOAST_MESSAGE } from '@constants/toast';
 import { useToastStore } from '@stores/toast';
 
 import spellCheckApi from '../api/spell';
@@ -23,10 +23,10 @@ const usePostSpellCheck = (
     ...options,
     mutationFn: (payload) => spellCheckApi.post({ ...payload }),
     onSuccess: () => {
-      showToast({ message: SPELLCHECK_STATE_MESSAGE.SUCCESS });
+      showToast({ message: TOAST_MESSAGE.SPELLCHECK.SUCCESS });
     },
     onError: () => {
-      showToast({ message: SPELLCHECK_STATE_MESSAGE.ERROR });
+      showToast({ message: TOAST_MESSAGE.SPELLCHECK.ERROR });
     },
   });
 };


### PR DESCRIPTION
## Summary

> 구현 내용 및 작업한 내역을 요약해서 적어주세요

- [x] [(api/memoFolder): 폴더 삭제 api body 제거](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/commit/9f36fd01f683a517ee8c01b0ce603a2c4b2ffacc)
- [x] [toast 메세지 상수화 및 유틸 함수명 변경](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/commit/3d36a3e2cd0dc3683617fd4de47a05dd4f56a700)
- [x] [(domain/끄적이는): 오늘 메모는 항상 아이콘 노출되도록 수정](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/pull/79/commits/b17fe13cfaf4f967d826998a634b60f0711c5898)
- [x] 저장하는 페이지의 전체적인 스타일 수정

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점을 적어주세요

- [(TooltipButton): 중복 button 태그 제거](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/pull/79/commits/60e35579c57f1fe5965284ac6b1e7906983cac1a)
- TooltipButton 컴포넌트를 생성해 리팩토링하는 과정에서 내부 button tag를 작성하지 않아 모든 카드의 아이콘 버튼이 클릭되지 않는 문제가 있었어요.
- 드롭다운 아이콘 버튼인 경우, Dropdown.Trigger(button tag) > Tooltip.Trigger(div tag)로 합성해 사용하고, 
- 아이콘 버튼인 경우 Tooltip.Trigger(div tag)를 사용하다보니 
- TooltipButton 컴포넌트를 설계하는 과정에서 button tag를 생략해 작성했던 것이 문제였어요.
- Tooltip.Trigger를 다형성 컴포넌트로 구현하면 TooltipButton 내부 로직이 쉽게 정리될 것 같은데...! 시간이 부족한 관계로 분기 처리로 대신 해결해두었어요.

## How To Test

> PR의 기능을 확인하는 방법을 상세하게 적어주세요
