### PR TITLE
[Fix/BAR-276] 수정 버튼 클릭 시 메모 텍스트 전부 노출 및 엔터 개행

### DIFF
--- a/src/domain/끄적이는/components/EditInput.tsx
+++ b/src/domain/끄적이는/components/EditInput.tsx
@@ -1,5 +1,6 @@
-import { type ChangeEvent, type KeyboardEvent, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
+import { MAIN_INPUT_MAX_LENGTH } from '@constants/config';
 import { type UseInputReturn } from '@hooks/useInput';
 
 import * as styles from './editInput.css';
@@ -10,47 +11,19 @@ interface EditInputProps {
 
 const EditInput = ({ inputProps }: EditInputProps) => {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
-  const [textareaHeight, setTextareaHeight] = useState<{
-    row: number;
-    lineBreak: Record<number, boolean>;
-  }>({
-    row: inputProps.value.split(/\r\n|\r|\n/).length,
-    lineBreak: {},
-  });
 
-  const handleResize = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    const { scrollHeight, clientHeight, value } = e.target;
+  useEffect(() => {
+    handleResize();
+  }, []);
 
-    if (value.length === 0) {
-      setTextareaHeight((prev) => ({
-        row: 1,
-        lineBreak: { ...prev.lineBreak, [e.target.value.length]: false },
-      }));
-    }
+  const handleResize = () => {
+    if (!inputRef.current) return;
 
-    if (scrollHeight > clientHeight) {
-      setTextareaHeight((prev) => ({
-        row: prev.row + 1,
-        lineBreak: { ...prev.lineBreak, [value.length - 1]: true },
-      }));
-    }
-
-    if (textareaHeight.lineBreak[value.length]) {
-      setTextareaHeight((prev) => ({
-        row: prev.row - 1,
-        lineBreak: { ...prev.lineBreak, [value.length]: false },
-      }));
-    }
-  };
-
-  const handleKeydownEnter = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.code === 'Enter') {
-      setTextareaHeight((prev) => ({
-        row: prev.row + 1,
-        lineBreak: { ...prev.lineBreak, [inputProps.value.length]: true },
-      }));
-      return;
-    }
+    inputRef.current.setAttribute('style', 'height: 0px');
+    inputRef.current.setAttribute(
+      'style',
+      `height: ${inputRef.current.scrollHeight}px`,
+    );
   };
 
   return (
@@ -60,16 +33,14 @@ const EditInput = ({ inputProps }: EditInputProps) => {
         ref={inputRef}
         className={styles.editInput}
         autoComplete="off"
-        rows={textareaHeight.row}
-        maxLength={500}
+        maxLength={MAIN_INPUT_MAX_LENGTH}
         onInput={handleResize}
-        onKeyDown={handleKeydownEnter}
       />
       <p className={styles.editInputTextCount}>
         <span className={styles.editTextCurrentCount}>
-          {inputProps.value.length}
+          {inputProps.value.length}&nbsp;
         </span>
-        / 500
+        /&nbsp;500
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

> 구현 내용 및 작업한 내역을 요약해서 적어주세요

- [x] [수정 버튼 클릭 시 메모 텍스트 전부 노출 및 엔터 개행](https://github.com/YAPP-Github/23rd-Web-Team-2-FE/commit/0c61ef813ce7aa196dd355cdd1b7709a1d7e68c2)

## To Reviewers

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점을 적어주세요

- 시간 내에 위 내용을 처리하기엔 불가피하게 DOM을 직접 조작하는 것외에 할 방법이 없는 것 같습니다... 
- 추후에 input 컴포넌트 전체 리팩토링 진행할 예정이예요.

## How To Test

> PR의 기능을 확인하는 방법을 상세하게 적어주세요
